### PR TITLE
Allow any type of service_registry config

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -31,8 +31,9 @@ resource "aws_ecs_service" "service" {
     for_each = var.service_registries
     content {
       registry_arn   = service_registries.value.registry_arn
-      container_name = service_registries.value.container_name
-      container_port = service_registries.value.container_port
+      container_name = lookup(service_registries.value, "container_name", null)
+      container_port = lookup(service_registries.value, "container_port", null)
+      port           = lookup(service_registries.value, "port", null)
     }
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -46,12 +46,8 @@ variable load_balancers {
 
 variable service_registries {
   description = "Allows you to register this service to a Cloud Map registry"
-  type = list(object({
-    registry_arn   = string
-    container_name = string
-    container_port = string
-  }))
-  default = []
+  type        = list(map(string))
+  default     = []
 }
 
 variable tags {


### PR DESCRIPTION
This gives more freedom to the `service_registries` variable to allow for optional fields. It also adds support for the `port` parameter of a service registry object