### PR TITLE
Create separate service definitions for auto-scaling, and static

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -55,7 +55,7 @@ resource "aws_ecs_service" "service" {
   }
 
   lifecycle {
-    ignore_changes = concat([], var.use_autoscaling ? [desired_count] : [])
+    ignore_changes = var.use_autoscaling ? [desired_count] : []
   }
 
   propagate_tags = "SERVICE"

--- a/main.tf
+++ b/main.tf
@@ -2,10 +2,6 @@ locals {
   security_group_id = length(var.security_group_id) > 0 ? var.security_group_id : aws_security_group.service_security_group[0].id
 }
 
-data "aws_ecs_cluster" "cluster" {
-  arn = var.cluster_id
-}
-
 resource "aws_ecs_service" "service" {
   name          = var.name
   cluster       = var.cluster_id
@@ -131,7 +127,7 @@ resource "aws_appautoscaling_target" "ecs_service_autoscaling_target" {
   max_capacity       = var.max_desired_count
   scalable_dimension = "ecs:service:DesiredCount"
   service_namespace  = "ecs"
-  resource_id        = "service/${data.aws_ecs_cluster.cluster.cluster_name}/${aws_ecs_service.service.name}"
+  resource_id        = "service/${var.cluster_name}/${aws_ecs_service.service.name}"
 }
 
 resource "aws_appautoscaling_policy" "ecs_service_autoscaling_policy" {

--- a/main.tf
+++ b/main.tf
@@ -62,7 +62,7 @@ resource "aws_security_group" "service_security_group" {
 
 # Service, with no Auto-scaling configured.
 resource "aws_ecs_service" "service_no_autoscaling" {
-  for_each = var.use_autoscaling ? [] : [1]
+  count = var.use_autoscaling ? 0 : 1
 
   name          = var.name
   cluster       = var.cluster_id
@@ -118,7 +118,7 @@ resource "aws_ecs_service" "service_no_autoscaling" {
 
 # Service wth Auto-scaling configured.
 resource "aws_ecs_service" "service_autoscaling" {
-  for_each = var.use_autoscaling ? [1] : []
+  count = var.use_autoscaling ? 1 : 0
 
   name          = var.name
   cluster       = var.cluster_id
@@ -176,7 +176,7 @@ resource "aws_ecs_service" "service_autoscaling" {
 }
 
 resource "aws_appautoscaling_target" "ecs_service_autoscaling_target" {
-  for_each = var.use_autoscaling ? [1] : []
+  count = var.use_autoscaling ? 1 : 0
 
   min_capacity       = var.min_desired_count
   max_capacity       = var.max_desired_count
@@ -186,7 +186,7 @@ resource "aws_appautoscaling_target" "ecs_service_autoscaling_target" {
 }
 
 resource "aws_appautoscaling_policy" "ecs_service_autoscaling_policy" {
-  for_each = var.use_autoscaling ? [1] : []
+  count = var.use_autoscaling ? 1 : 0
 
   name               = "ecs-fargate-service-autoscaling-policy"
   service_namespace  = aws_appautoscaling_target.ecs_service_autoscaling_target[0].service_namespace

--- a/main.tf
+++ b/main.tf
@@ -55,7 +55,7 @@ resource "aws_ecs_service" "service" {
   }
 
   lifecycle {
-    ignore_changes = var.use_autoscaling ? [desired_count] : []
+    ignore_changes = [desired_count]
   }
 
   propagate_tags = "SERVICE"

--- a/main.tf
+++ b/main.tf
@@ -1,65 +1,6 @@
 locals {
   security_group_id = length(var.security_group_id) > 0 ? var.security_group_id : aws_security_group.service_security_group[0].id
-}
-
-resource "aws_ecs_service" "service" {
-  name          = var.name
-  cluster       = var.cluster_id
-  desired_count = var.use_autoscaling ? null : var.desired_count
-
-  task_definition = aws_ecs_task_definition.task.arn
-  launch_type     = "FARGATE"
-
-  network_configuration {
-    security_groups  = [local.security_group_id]
-    subnets          = var.subnet_ids
-    assign_public_ip = false
-  }
-
-  deployment_controller {
-    type = "ECS"
-  }
-
-  health_check_grace_period_seconds = var.health_check_grace_period_seconds
-
-  dynamic "capacity_provider_strategy" {
-    for_each = var.capacity_provider_strategies
-    content {
-      base              = capacity_provider_strategy.value.base
-      capacity_provider = capacity_provider_strategy.value.capacity_provider
-      weight            = capacity_provider_strategy.value.weight
-    }
-  }
-
-  dynamic "load_balancer" {
-    for_each = var.load_balancers
-    content {
-      target_group_arn = load_balancer.value.target_group_arn
-      container_name   = load_balancer.value.container_name
-      container_port   = load_balancer.value.container_port
-    }
-  }
-
-  dynamic "service_registries" {
-    for_each = var.service_registries
-    content {
-      registry_arn   = service_registries.value.registry_arn
-      container_name = lookup(service_registries.value, "container_name", null)
-      container_port = lookup(service_registries.value, "container_port", null)
-      port           = lookup(service_registries.value, "port", null)
-    }
-  }
-
-  lifecycle {
-    ignore_changes = [desired_count]
-  }
-
-  propagate_tags = "SERVICE"
-  tags           = var.tags
-}
-
-locals {
-  role_arn = length(var.execution_role_arn) > 0 ? var.execution_role_arn : aws_iam_role.execution_role[0].arn
+  role_arn          = length(var.execution_role_arn) > 0 ? var.execution_role_arn : aws_iam_role.execution_role[0].arn
 }
 
 resource "aws_ecs_task_definition" "task" {
@@ -119,6 +60,120 @@ resource "aws_security_group" "service_security_group" {
   tags = var.tags
 }
 
+# Service, with no Auto-scaling configured.
+resource "aws_ecs_service" "service_no_autoscaling" {
+  for_each = var.use_autoscaling ? [] : [1]
+
+  name          = var.name
+  cluster       = var.cluster_id
+  desired_count = var.desired_count
+
+  task_definition = aws_ecs_task_definition.task.arn
+  launch_type     = "FARGATE"
+
+  network_configuration {
+    security_groups  = [local.security_group_id]
+    subnets          = var.subnet_ids
+    assign_public_ip = false
+  }
+
+  deployment_controller {
+    type = "ECS"
+  }
+
+  health_check_grace_period_seconds = var.health_check_grace_period_seconds
+
+  dynamic "capacity_provider_strategy" {
+    for_each = var.capacity_provider_strategies
+    content {
+      base              = capacity_provider_strategy.value.base
+      capacity_provider = capacity_provider_strategy.value.capacity_provider
+      weight            = capacity_provider_strategy.value.weight
+    }
+  }
+
+  dynamic "load_balancer" {
+    for_each = var.load_balancers
+    content {
+      target_group_arn = load_balancer.value.target_group_arn
+      container_name   = load_balancer.value.container_name
+      container_port   = load_balancer.value.container_port
+    }
+  }
+
+  dynamic "service_registries" {
+    for_each = var.service_registries
+    content {
+      registry_arn   = service_registries.value.registry_arn
+      container_name = lookup(service_registries.value, "container_name", null)
+      container_port = lookup(service_registries.value, "container_port", null)
+      port           = lookup(service_registries.value, "port", null)
+    }
+  }
+
+  propagate_tags = "SERVICE"
+  tags           = var.tags
+}
+
+
+# Service wth Auto-scaling configured.
+resource "aws_ecs_service" "service_autoscaling" {
+  for_each = var.use_autoscaling ? [1] : []
+
+  name          = var.name
+  cluster       = var.cluster_id
+  desired_count = var.min_desired_count
+
+  task_definition = aws_ecs_task_definition.task.arn
+  launch_type     = "FARGATE"
+
+  network_configuration {
+    security_groups  = [local.security_group_id]
+    subnets          = var.subnet_ids
+    assign_public_ip = false
+  }
+
+  deployment_controller {
+    type = "ECS"
+  }
+
+  health_check_grace_period_seconds = var.health_check_grace_period_seconds
+
+  dynamic "capacity_provider_strategy" {
+    for_each = var.capacity_provider_strategies
+    content {
+      base              = capacity_provider_strategy.value.base
+      capacity_provider = capacity_provider_strategy.value.capacity_provider
+      weight            = capacity_provider_strategy.value.weight
+    }
+  }
+
+  dynamic "load_balancer" {
+    for_each = var.load_balancers
+    content {
+      target_group_arn = load_balancer.value.target_group_arn
+      container_name   = load_balancer.value.container_name
+      container_port   = load_balancer.value.container_port
+    }
+  }
+
+  dynamic "service_registries" {
+    for_each = var.service_registries
+    content {
+      registry_arn   = service_registries.value.registry_arn
+      container_name = lookup(service_registries.value, "container_name", null)
+      container_port = lookup(service_registries.value, "container_port", null)
+      port           = lookup(service_registries.value, "port", null)
+    }
+  }
+
+  lifecycle {
+    ignore_changes = [desired_count]
+  }
+
+  propagate_tags = "SERVICE"
+  tags           = var.tags
+}
 
 resource "aws_appautoscaling_target" "ecs_service_autoscaling_target" {
   for_each = var.use_autoscaling ? [1] : []
@@ -127,14 +182,16 @@ resource "aws_appautoscaling_target" "ecs_service_autoscaling_target" {
   max_capacity       = var.max_desired_count
   scalable_dimension = "ecs:service:DesiredCount"
   service_namespace  = "ecs"
-  resource_id        = "service/${var.cluster_name}/${aws_ecs_service.service.name}"
+  resource_id        = "service/${var.cluster_name}/${aws_ecs_service.service_autoscaling[0].name}"
 }
 
 resource "aws_appautoscaling_policy" "ecs_service_autoscaling_policy" {
+  for_each = var.use_autoscaling ? [1] : []
+
   name               = "ecs-fargate-service-autoscaling-policy"
-  service_namespace  = aws_appautoscaling_target.ecs_service_autoscaling_target.service_namespace
-  scalable_dimension = aws_appautoscaling_target.ecs_service_autoscaling_target.scalable_dimension
-  resource_id        = aws_appautoscaling_target.ecs_service_autoscaling_target.resource_id
+  service_namespace  = aws_appautoscaling_target.ecs_service_autoscaling_target[0].service_namespace
+  scalable_dimension = aws_appautoscaling_target.ecs_service_autoscaling_target[0].scalable_dimension
+  resource_id        = aws_appautoscaling_target.ecs_service_autoscaling_target[0].resource_id
   policy_type        = "TargetTrackingScaling"
 
   target_tracking_scaling_policy_configuration {

--- a/variables.tf
+++ b/variables.tf
@@ -12,7 +12,7 @@ variable "cluster_id" {
 }
 
 variable "cluster_name" {
-  type = string
+  type        = string
   description = "The name of the ECS cluster this service will run in."
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -11,6 +11,11 @@ variable "cluster_id" {
   EOF
 }
 
+variable "cluster_name" {
+  type = string
+  description = "The name of the ECS cluster this service will run in."
+}
+
 variable "desired_count" {
   type        = number
   description = "If not using Application Auto-scaling, the number of tasks to keep alive at all times"

--- a/variables.tf
+++ b/variables.tf
@@ -175,7 +175,7 @@ variable "capacity_provider_strategies" {
 }
 
 variable "ephemeral_storage_gib" {
-  description = "The total amount, in GiB, of ephemeral storage to set for the task. The minimum supported value is 20 GiB and the maximum supported value is 200 GiB."
+  description = "The total amount, in GiB, of ephemeral storage to set for the task. The minimum supported value is 21 GiB and the maximum supported value is 200 GiB."
   type        = number
   default     = 21
 }

--- a/variables.tf
+++ b/variables.tf
@@ -177,5 +177,5 @@ variable "capacity_provider_strategies" {
 variable "ephemeral_storage_gib" {
   description = "The total amount, in GiB, of ephemeral storage to set for the task. The minimum supported value is 20 GiB and the maximum supported value is 200 GiB."
   type        = number
-  default     = 20
+  default     = 21
 }


### PR DESCRIPTION
Signed-off-by: Dipack <dipack@transcend.io>

# Pull Request

## Related Github Issues

- links https://transcend.height.app/T-12183

## Description

We now create separate ECS service definitions, depending on if we're auto-scaling or not.

I have tested this PR with the monorepo, and I can get it to the planning stage, which means that it should work during applies, once we import the services correctly.

## Security Implications

- _[none]_

## System Availability

- _[none]_
