### PR TITLE
Use a resource label, for ALB scaling purposes.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -115,7 +115,6 @@ resource "aws_ecs_service" "service_no_autoscaling" {
   tags           = var.tags
 }
 
-
 # Service wth Auto-scaling configured.
 resource "aws_ecs_service" "service_autoscaling" {
   count = var.use_autoscaling ? 1 : 0
@@ -202,6 +201,7 @@ resource "aws_appautoscaling_policy" "ecs_service_autoscaling_policy" {
     target_value       = var.scaling_target_value
     predefined_metric_specification {
       predefined_metric_type = var.scaling_metric
+      resource_label         = var.scaling_metric == "ALBRequestCountPerTarget" ? var.alb_scaling_target_resource_id : null
     }
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -52,6 +52,12 @@ variable "scaling_metric" {
   default     = "ALBRequestCountPerTarget"
 }
 
+variable "alb_scaling_target_resource_id" {
+  type        = string
+  description = "If using Application auto-scaling, and ALBRequestCountPerTarget as the scaling metric, use this resource ID as the measure"
+  default     = ""
+}
+
 variable "vpc_id" {
   description = "ID of the VPC the alb is in"
 }


### PR DESCRIPTION
Signed-off-by: Dipack <dipack@transcend.io>

Tested this out in https://github.com/transcend-io/main/pull/14705

# Pull Request

## Related Github Issues

- _[none]_

## Description

TODO

## Security Implications

- _[none]_

## System Availability

- _[none]_
