### PR TITLE
Add possibility to set enable_execute_command variable

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -71,6 +71,8 @@ resource "aws_ecs_service" "service_no_autoscaling" {
   task_definition = aws_ecs_task_definition.task.arn
   launch_type     = "FARGATE"
 
+  enable_execute_command = var.enable_execute_command
+
   network_configuration {
     security_groups  = [local.security_group_id]
     subnets          = var.subnet_ids
@@ -125,6 +127,8 @@ resource "aws_ecs_service" "service_autoscaling" {
 
   task_definition = aws_ecs_task_definition.task.arn
   launch_type     = "FARGATE"
+
+  enable_execute_command = var.enable_execute_command
 
   network_configuration {
     security_groups  = [local.security_group_id]

--- a/variables.tf
+++ b/variables.tf
@@ -185,3 +185,9 @@ variable "ephemeral_storage_gib" {
   type        = number
   default     = 21
 }
+
+variable "enable_execute_command" {
+  description = "Specifies whether to enable Amazon ECS Exec for the tasks within the service."
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
# Pull Request

## Related Github Issues

- _[none]_

## Description

This PR adds possibility to set enable_execute_command, which is used to allow users to execute command inside of task using aws cli

## Security Implications

- _[none]_

## System Availability

- _[none]_
