### PR TITLE
Allow specifying ingress cidr blocks

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -40,6 +40,7 @@ resource "aws_security_group" "service_security_group" {
       from_port       = ingress.value.container_port
       to_port         = ingress.value.container_port
       security_groups = var.alb_security_group_ids
+      cidr_blocks     = var.ingress_cidr_blocks
       protocol        = "tcp"
     }
   }

--- a/variables.tf
+++ b/variables.tf
@@ -139,7 +139,7 @@ variable "alb_security_group_ids" {
 variable "ingress_cidr_blocks" {
   type        = list(string)
   description = "CIDR blocks to allow accessing the ECS tasks. This is usually not specified, as the alb_security_group_ids covers the ingress, but in some cases is useful if using an NLB instead of an ALB, which cannot attach security groups to itself."
-  default.    = null
+  default     = null
 }
 
 variable "execution_role_arn" {

--- a/variables.tf
+++ b/variables.tf
@@ -132,7 +132,14 @@ variable "health_check_grace_period_seconds" {
 
 variable "alb_security_group_ids" {
   type        = list(string)
-  description = "The ids of all security groups set on the ALB. We require that the tasks can only talk to the ALB"
+  description = "The ids of all security groups set on the ALB. We require that the tasks can only talk to the ALB. If using an NLB, use ingress_cidr_blocks instead"
+  default     = null
+}
+
+variable "ingress_cidr_blocks" {
+  type        = list(string)
+  description = "CIDR blocks to allow accessing the ECS tasks. This is usually not specified, as the alb_security_group_ids covers the ingress, but in some cases is useful if using an NLB instead of an ALB, which cannot attach security groups to itself."
+  default.    = null
 }
 
 variable "execution_role_arn" {


### PR DESCRIPTION
Useful for when being used with NLBs instead of ALBs, and NLBs are necessary for terminating fargate task SSL on the server, not on the load balancer, needed for mTLS